### PR TITLE
Add @example jsDoc to Typescript comments

### DIFF
--- a/src/rules/require-comment/rule.test.ts
+++ b/src/rules/require-comment/rule.test.ts
@@ -22,6 +22,8 @@ ruleTester.run(ruleName, rule, {
     test('string-deprecated'),
     test('object-property-deprecated'),
     test('string-inline-comment'),
+    test('number-example-integer'),
+    test('string-list-example'),
   ],
   invalid: [
     {
@@ -104,6 +106,10 @@ ruleTester.run(ruleName, rule, {
     },
     {
       ...test('zod-infer', true),
+      errors: [{ messageId: 'comment' }],
+    },
+    {
+      ...test('string-example-wrong', true),
       errors: [{ messageId: 'comment' }],
     },
   ],

--- a/src/rules/require-comment/tests/number-example-integer.ts
+++ b/src/rules/require-comment/tests/number-example-integer.ts
@@ -1,0 +1,12 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+/**
+ * a number
+ * @example 1
+ */
+export const ZodNumber = z
+  .number()
+  .openapi({ description: 'a number', example: 1 });

--- a/src/rules/require-comment/tests/string-example-wrong.fix.ts
+++ b/src/rules/require-comment/tests/string-example-wrong.fix.ts
@@ -1,0 +1,12 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+/**
+ * correct
+ * @example 'hello world'
+ */
+export const ZodString = z
+  .string()
+  .openapi({ description: 'correct', example: 'hello world' });

--- a/src/rules/require-comment/tests/string-example-wrong.ts
+++ b/src/rules/require-comment/tests/string-example-wrong.ts
@@ -1,0 +1,11 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+/**
+ * wrong
+ */
+export const ZodString = z
+  .string()
+  .openapi({ description: 'correct', example: 'hello world' });

--- a/src/rules/require-comment/tests/string-list-example.ts
+++ b/src/rules/require-comment/tests/string-list-example.ts
@@ -1,0 +1,12 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+/**
+ * a list of strings
+ * @example ['hello']
+ */
+export const ZodStringList = z
+  .array(z.string())
+  .openapi({ description: 'a list of strings', example: ['hello'] });


### PR DESCRIPTION
Adds the @example jsDoc tag for `example` and `examples` added to `.openapi()`