### PR TITLE
Only set example for basic literal values

### DIFF
--- a/src/rules/require-comment/rule.test.ts
+++ b/src/rules/require-comment/rule.test.ts
@@ -24,6 +24,8 @@ ruleTester.run(ruleName, rule, {
     test('string-inline-comment'),
     test('number-example-integer'),
     test('string-list-example'),
+    test('object-property-example'),
+    test('string-examples'),
   ],
   invalid: [
     {

--- a/src/rules/require-comment/tests/object-property-example.ts
+++ b/src/rules/require-comment/tests/object-property-example.ts
@@ -1,0 +1,19 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+/**
+ * object description
+ */
+export const ZodObject = z
+  .object({
+    /**
+     * prop description
+     * @example "prop"
+     */
+    prop: z
+      .string()
+      .openapi({ description: 'prop description', example: 'prop' }),
+  })
+  .openapi({ description: 'object description' });

--- a/src/rules/require-comment/tests/string-example-wrong.fix.ts
+++ b/src/rules/require-comment/tests/string-example-wrong.fix.ts
@@ -5,7 +5,7 @@ extendZodWithOpenApi(z);
 
 /**
  * correct
- * @example 'hello world'
+ * @example "hello world"
  */
 export const ZodString = z
   .string()

--- a/src/rules/require-comment/tests/string-examples.ts
+++ b/src/rules/require-comment/tests/string-examples.ts
@@ -1,0 +1,14 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+/**
+ * a description
+ * @example "multiple"
+ */
+export const ZodString = z.string().openapi({
+  description: 'a description',
+  default: 'hello',
+  examples: ['multiple', 'examples'],
+});

--- a/src/rules/require-comment/tests/string-list-example.ts
+++ b/src/rules/require-comment/tests/string-list-example.ts
@@ -5,7 +5,6 @@ extendZodWithOpenApi(z);
 
 /**
  * a list of strings
- * @example ['hello']
  */
 export const ZodStringList = z
   .array(z.string())


### PR DESCRIPTION
I naively was grabbing the raw text's value and using it as the example. This caused big issues especially if there was formatting for the examples value which spanned over multiple lines. This PR changes example to only be set for basic literal values.