### PR TITLE
Copy other jsDoc tags in inferred Typescript comments

### DIFF
--- a/src/rules/require-comment/rule.test.ts
+++ b/src/rules/require-comment/rule.test.ts
@@ -26,6 +26,7 @@ ruleTester.run(ruleName, rule, {
     test('string-list-example'),
     test('object-property-example'),
     test('string-examples'),
+    test('object-property-referenced-example'),
   ],
   invalid: [
     {

--- a/src/rules/require-comment/tests/object-property-referenced-example.ts
+++ b/src/rules/require-comment/tests/object-property-referenced-example.ts
@@ -1,0 +1,32 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+/**
+ * object description
+ */
+export const ZodObject = z
+  .object({
+    /**
+     * prop description
+     * @example "hello"
+     */
+    prop: z
+      .string()
+      .openapi({ description: 'prop description', example: 'hello' }),
+  })
+  .openapi({ description: 'object description' });
+
+/**
+ * new object description
+ */
+export const NewZodObject = z
+  .object({
+    /**
+     * prop description
+     * @example "hello"
+     */
+    copyProp: ZodObject.shape.prop,
+  })
+  .openapi({ description: 'new object description' });

--- a/src/rules/require-example/rule.test.ts
+++ b/src/rules/require-example/rule.test.ts
@@ -16,12 +16,13 @@ const ruleTester = new ESLintUtils.RuleTester({
 });
 
 ruleTester.run(ruleName, rule, {
-  valid: [test('enum-no-example')],
+  valid: [],
   invalid: [
     { ...test('string-no-example'), errors: [{ messageId: 'required' }] },
     { ...test('number-no-example'), errors: [{ messageId: 'required' }] },
     { ...test('boolean-no-example'), errors: [{ messageId: 'required' }] },
     { ...test('record-no-example'), errors: [{ messageId: 'required' }] },
+    { ...test('enum-no-example'), errors: [{ messageId: 'required' }] },
     {
       ...test('string-optional-no-example'),
       errors: [{ messageId: 'required' }],

--- a/src/rules/require-example/tests/enum-no-example.ts
+++ b/src/rules/require-example/tests/enum-no-example.ts
@@ -3,4 +3,4 @@ import { z } from 'zod';
 
 extendZodWithOpenApi(z);
 
-export const ZodPrimative = z.enum(['a']).openapi({ description: 'test' });
+export const ZodPrimative = z.enum(['a', 'b']).openapi({ description: 'test' });

--- a/src/util/type.ts
+++ b/src/util/type.ts
@@ -107,14 +107,9 @@ const getInferredComment = <T extends TSESTree.Node>(
   const comment = ts.displayPartsToString(
     aliasedSymbol.getDocumentationComment(checker),
   );
-  if (!comment) {
-    const jsDoc = aliasedSymbol.getJsDocTags(checker);
-    const tags = jsDoc.map(
-      (doc) => `@${doc.name} ${doc?.text?.[0].text ?? ''}`,
-    );
-    return tags.join(' ');
-  }
-  return comment;
+  const jsDoc = aliasedSymbol.getJsDocTags(checker);
+  const tags = jsDoc.map((doc) => `@${doc.name} ${doc?.text?.[0].text ?? ''}`);
+  return `${comment}${comment && tags.length ? '\n' : ''}${tags.join(' ')}`;
 };
 
 export { getType, getInferredComment };

--- a/src/util/type.ts
+++ b/src/util/type.ts
@@ -71,6 +71,7 @@ const getType = <T extends TSESTree.Node>(
       'ZodNumber',
       'ZodBoolean',
       'ZodRecord',
+      'ZodEnum',
     ].includes(unwrapType ?? name),
   };
 };


### PR DESCRIPTION
This also makes enums require example.