### PR TITLE
require-example: Add `examples` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,13 @@ type Person = z.infer<typeof PersonSchema>; // ℹ️ This comment is synced wit
 
 ### require-example
 
-Requires that the `.openapi()` method contains an `example` key for Zod primatives. This makes our generated documentation much nicer. This includes:
+Requires that the `.openapi()` method contains an `example`, `examples` key for Zod primatives. This makes our generated documentation much nicer. This includes:
 
 - ZodBoolean
 - ZodNumber
 - ZodString
 - ZodRecord
+- ZodEnum
 
 ```ts
 const UserIdSchema = z.string().uuid(); // ❌ error (no example)
@@ -205,6 +206,10 @@ const UserIdSchema = z
   .uuid()
   .openapi({ example: '48948579-f117-47e4-bc05-12f28e7fdccd' }); // ✅ correct
 ```
+
+By default this rule looks for the `example` key. If you wish to use the `examples` key which is required in Open API 3.1 pass the key `examples` in the options argument of your rule configuration.
+
+eg. `'zod-to-openapi/require-example': ['error', 'examples']`
 
 ### prefer-openapi-last
 

--- a/src/rules/require-example/rule.test.ts
+++ b/src/rules/require-example/rule.test.ts
@@ -16,7 +16,15 @@ const ruleTester = new ESLintUtils.RuleTester({
 });
 
 ruleTester.run(ruleName, rule, {
-  valid: [],
+  valid: [
+    {
+      ...test('string-example'),
+    },
+    {
+      ...test('string-examples'),
+      options: ['examples'],
+    },
+  ],
   invalid: [
     { ...test('string-no-example'), errors: [{ messageId: 'required' }] },
     { ...test('number-no-example'), errors: [{ messageId: 'required' }] },
@@ -26,6 +34,11 @@ ruleTester.run(ruleName, rule, {
     {
       ...test('string-optional-no-example'),
       errors: [{ messageId: 'required' }],
+    },
+    {
+      ...test('string-no-example'),
+      errors: [{ messageId: 'required' }],
+      options: ['examples'],
     },
   ],
 });

--- a/src/rules/require-example/tests/string-example.ts
+++ b/src/rules/require-example/tests/string-example.ts
@@ -1,0 +1,8 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+export const ZodString = z
+  .string()
+  .openapi({ description: 'test', example: 'string' });

--- a/src/rules/require-example/tests/string-examples.ts
+++ b/src/rules/require-example/tests/string-examples.ts
@@ -1,0 +1,8 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);
+
+export const ZodString = z
+  .string()
+  .openapi({ description: 'test', examples: ['string'] });


### PR DESCRIPTION
Adds support for the `examples` key instead of `example`. 

In Open API 3.1, `examples` is required and `example` is invalid.